### PR TITLE
feat: extended main job sites description parser

### DIFF
--- a/supabase/functions/_shared/jobDescriptionParser.ts
+++ b/supabase/functions/_shared/jobDescriptionParser.ts
@@ -182,17 +182,11 @@ export function parseRemoteOkJobDescription({
   let description: string | undefined;
 
   if (descriptionContainer) {
-    // Define a regex that matches from the beginning of the string to the first occurrence of <div class="markdown">
-    // and includes the <div class="markdown"> tag itself in the match
-    const beforeMarkdownRegex = /^.*?(<div class="markdown">)/s;
-
-    // Replace the matched portion with just the <div class="markdown"> tag to remove everything before it
-    const cleanedUp = descriptionContainer.innerHTML.replace(
-      beforeMarkdownRegex,
-      "$1"
-    );
-
-    description = turndownService.turndown(cleanedUp);
+    const nodeToRemove = document.querySelector(".company_profile");
+    if (nodeToRemove) {
+      nodeToRemove.remove();
+    }
+    description = turndownService.turndown(descriptionContainer.innerHTML);
   }
 
   return {


### PR DESCRIPTION
![Pasted Graphic](https://github.com/beastx-ro/first2apply/assets/76562132/0ad90442-1433-4e4a-ba3d-3883f9acdf8e)


- Some UI bugs I still need to look into.
- Also would like to have the job slot that I clicked and displaying the description being highlighted
- Jobs listing order is inverted, we show first the last one on the site
- React scanning jobs looks buggy, need to refresh to actually see it

I will extend for the other sites providers as well.
