### PR TITLE
Add support for deprecated column in the sql script

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -8,6 +8,7 @@ public.sites (
   logo_url text not null,
   blacklisted_paths text[] not null default '{/}'::text[],
   provider text not null,
+  deprecated boolean not null default false,
   constraint sites_pkey primary key (id)
 ) tablespace pg_default;
 


### PR DESCRIPTION
Related to https://github.com/beastx-ro/first2apply/commit/978d1f09b762bd67e25cb9fb36282e3a985d5c28

Context:
I was getting the error in the image when trying to import the csv file:

![image](https://github.com/user-attachments/assets/8cf25fe0-47ca-4fc7-b859-72aa3d9fcff4)
