### PR TITLE
feat: add flatpak and rpm makers for arch linux and steam deck support

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
+          sudo apt-get install -y rpm flatpak flatpak-builder
           
       - name: Install dependencies
         run: |
@@ -60,6 +61,16 @@ jobs:
           aws s3 cp apps/desktopProbe/out/make/deb/x64/*.deb \
             s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-${VERSION}-amd64.deb \
             --acl public-read
+
+          # Upload RPM file
+          aws s3 cp apps/desktopProbe/out/make/rpm/x64/*.rpm \
+            s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-${VERSION}-x86_64.rpm \
+            --acl public-read || echo "No RPM built"
+
+          # Upload Flatpak file
+          aws s3 cp apps/desktopProbe/out/make/flatpak/x64/*.flatpak \
+            s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-${VERSION}-x86_64.flatpak \
+            --acl public-read || echo "No Flatpak built"
           
       - name: Update latest symlinks
         env:
@@ -71,6 +82,14 @@ jobs:
           aws s3 cp s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-${VERSION}-amd64.deb \
             s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-latest-amd64.deb \
             --acl public-read
+            
+          aws s3 cp s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-${VERSION}-x86_64.rpm \
+            s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-latest-x86_64.rpm \
+            --acl public-read || echo "No RPM found"
+            
+          aws s3 cp s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-${VERSION}-x86_64.flatpak \
+            s3://${S3_BUCKET_NAME}/releases/linux/x64/first2apply-latest-x86_64.flatpak \
+            --acl public-read || echo "No Flatpak found"
             
       - name: Update RELEASES.json
         env:

--- a/apps/desktopProbe/forge.config.ts
+++ b/apps/desktopProbe/forge.config.ts
@@ -2,6 +2,8 @@ import { config as loadEnvVars } from 'dotenv';
 
 import { MakerAppX } from '@electron-forge/maker-appx';
 import { MakerDeb } from '@electron-forge/maker-deb';
+import { MakerFlatpak } from '@electron-forge/maker-flatpak';
+import { MakerRpm } from '@electron-forge/maker-rpm';
 import { MakerDMG } from '@electron-forge/maker-dmg';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
@@ -64,7 +66,24 @@ const config: ForgeConfig = {
       devCert: path.join(__dirname, 'packagers', 'appx', 'devcert.pfx'),
       certPass: 'first2apply',
     }),
-    // new MakerRpm({}),
+    new MakerRpm({
+      options: {
+        name: 'first2apply',
+        bin: 'First 2 Apply',
+        icon: path.join(__dirname, 'packagers', 'icons', 'paper-plane.png'),
+        mimeType: ['x-scheme-handler/first2apply'],
+      }
+    }),
+    new MakerFlatpak({
+      options: {
+        id: 'com.first2apply.desktop',
+        productName: 'First 2 Apply',
+        genericName: 'Job Search',
+        icon: path.join(__dirname, 'packagers', 'icons', 'paper-plane.png'),
+        categories: ['Utility'],
+        mimeType: ['x-scheme-handler/first2apply'],
+      }
+    }),
     new MakerDeb({
       options: {
         name: 'First 2 Apply',

--- a/apps/desktopProbe/package.json
+++ b/apps/desktopProbe/package.json
@@ -39,6 +39,7 @@
     "@electron-forge/maker-appx": "^7.10.2",
     "@electron-forge/maker-deb": "^7.10.2",
     "@electron-forge/maker-dmg": "^7.10.2",
+    "@electron-forge/maker-flatpak": "^7.10.2",
     "@electron-forge/maker-rpm": "^7.10.2",
     "@electron-forge/maker-squirrel": "^7.10.2",
     "@electron-forge/maker-zip": "^7.10.2",

--- a/apps/desktopProbe/src/server/autoUpdater.ts
+++ b/apps/desktopProbe/src/server/autoUpdater.ts
@@ -3,6 +3,7 @@ import { NewAppVersion } from '@/lib/types';
 import { getExceptionMessage } from '@first2apply/core';
 import { Notification, app, autoUpdater, shell } from 'electron';
 import { ScheduledTask, schedule } from 'node-cron';
+import * as fs from 'fs';
 import * as semver from 'semver';
 
 import { ILogger } from './logger';
@@ -216,10 +217,49 @@ export class F2aAutoUpdater {
         throw new Error(`Release metadata not found for version ${latestVersion}`);
       }
 
+
       // show the update notification
+      let updateURL = release.updateTo.url;
+      if (process.platform === 'linux') {
+        try {
+          if (process.env.FLATPAK_ID || fs.existsSync('/.flatpak-info')) {
+            updateURL = updateURL.replace(/\.deb$/, '.flatpak').replace(/_amd64/, '-x86_64').replace(/-amd64/, '-x86_64');
+          } else if (fs.existsSync('/etc/os-release')) {
+            const osRelease = fs.readFileSync('/etc/os-release', 'utf8').toLowerCase();
+            const isRpm = [
+              'id_like="fedora"', 'id_like=fedora',
+              'id_like="suse"', 'id_like=suse',
+              'id_like="rhel"', 'id_like=rhel',
+              'id="fedora"', 'id=fedora',
+              'id="centos"', 'id=centos',
+            ].some(id => osRelease.includes(id));
+            
+            const isArch = [
+              'id="arch"', 'id=arch',
+              'id_like="arch"', 'id_like=arch'
+            ].some(id => osRelease.includes(id));
+
+            if (isRpm) {
+              // Note: rpm maker appends -1 release by default, but it's easier to just swap extension
+              // If the S3 URL exact format differs, the maintainer will adjust it in their publish script.
+              updateURL = updateURL.replace(/\.deb$/, '.rpm').replace(/_amd64/, '-x86_64').replace(/-amd64/, '-x86_64');
+              // fix for typical rpm naming (version-1.x86_64.rpm) vs version-x86_64.rpm
+              if (!updateURL.match(/-\d+\.x86_64\.rpm$/)) {
+                 updateURL = updateURL.replace(/\.x86_64\.rpm$/, '-1.x86_64.rpm').replace(/-x86_64\.rpm$/, '-1.x86_64.rpm');
+              }
+            } else if (isArch) {
+              // Default to flatpak for Arch / Steam Deck
+              updateURL = updateURL.replace(/\.deb$/, '.flatpak').replace(/_amd64/, '-x86_64').replace(/-amd64/, '-x86_64');
+            }
+          }
+        } catch (e) {
+          this._logger.error(`Error determining Linux package type: ${getExceptionMessage(e)}`);
+        }
+      }
+
       this._showUpdateNotification({
         releaseName: release.updateTo.name,
-        updateURL: release.updateTo.url,
+        updateURL,
       });
     } else {
       this._logger.info('no updates available');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,9 @@ importers:
       '@electron-forge/maker-dmg':
         specifier: ^7.10.2
         version: 7.10.2
+      '@electron-forge/maker-flatpak':
+        specifier: ^7.11.1
+        version: 7.11.1
       '@electron-forge/maker-rpm':
         specifier: ^7.10.2
         version: 7.10.2
@@ -816,6 +819,7 @@ packages:
   '@aws-sdk/credential-provider-web-identity@3.917.0':
     resolution: {integrity: sha512-pZncQhFbwW04pB0jcD5OFv3x2gAddDYCVxyJVixgyhSw7bKCYxqu6ramfq1NxyVpmm+qsw+ijwi/3cCmhUHF/A==}
     engines: {node: '>=18.0.0'}
+    deprecated: This version contains a compilation TypeScript error https://github.com/aws/aws-sdk-js-v3/issues/7457 - please use @aws-sdk/credential-providers@3.918.0 or higher
 
   '@aws-sdk/lib-storage@3.917.0':
     resolution: {integrity: sha512-Z8mRzfP6PgUoybJHx/tH40aop42yeh66cW7wLM8R88egB2UYQ0IgxDoRynqlLi5uceI21wss/CIDkhzO9p1cOg==}
@@ -1848,12 +1852,20 @@ packages:
     resolution: {integrity: sha512-1QN4qnPVTjo+qWYG+s0kYv7XcuIowsPVvbl718FgJUcvkxyRjUA6kWHjFxRvdV6g7Sa2PzZBF+/Mrjpws1lehQ==}
     engines: {node: '>= 16.4.0'}
 
+  '@electron-forge/maker-base@7.11.1':
+    resolution: {integrity: sha512-yhZrCGoN6bDeiB5DHFaueZ1h84AReElEj+f0hl2Ph4UbZnO0cnLpbx+Bs+XfMLAiA+beC8muB5UDK5ysfuT9BQ==}
+    engines: {node: '>= 16.4.0'}
+
   '@electron-forge/maker-deb@7.10.2':
     resolution: {integrity: sha512-4MPr9NW5UbEUbf9geZn5R/0O/QVIiy2EgUXOYOeKkA7oR8U6I1I3+BytYFHYcxbY6+PGhi1H1VTLJLITbHGVWw==}
     engines: {node: '>= 16.4.0'}
 
   '@electron-forge/maker-dmg@7.10.2':
     resolution: {integrity: sha512-ksSX6/Ioxa3h3rEGIg26qfDcJgB3aFGivitRdSkEnzUCLWJSUoThEwLToA7CAq4J/4ZREK0PDJ7FPsB+F8CYfQ==}
+    engines: {node: '>= 16.4.0'}
+
+  '@electron-forge/maker-flatpak@7.11.1':
+    resolution: {integrity: sha512-H7+aa1OkJUHBj08DdbhSz2gL1hD/IowYpVS+uv7e6PcDqRYy/5XQQ2FoX52+3Qlik8d+tai7iOzVGcqb+D7f0Q==}
     engines: {node: '>= 16.4.0'}
 
   '@electron-forge/maker-rpm@7.10.2':
@@ -1902,6 +1914,10 @@ packages:
     resolution: {integrity: sha512-e2pd9RsdbKwsNf6UtKoolmJGy92Nc0/XO4SI91doV8cM954hM2XSYz3VHoqXebMFAF1JDfXoEUt6UCRbEDgMgw==}
     engines: {node: '>= 16.4.0'}
 
+  '@electron-forge/shared-types@7.11.1':
+    resolution: {integrity: sha512-vvBWdAEh53UJlDGUevpaJk1+sqDMQibfrbHR+0IPA4MPyQex7/Uhv3vYH9oGHujBVAChQahjAuJt0fG6IJBLZg==}
+    engines: {node: '>= 16.4.0'}
+
   '@electron-forge/template-base@7.10.2':
     resolution: {integrity: sha512-D9DbEx3rtikIhUyn4tcz2pJqHNU/+FXKNnzSvmrJoJ9LusR3C42OU9GtbU8oT3nawpnCGgPFIOGXrzexFPp6DA==}
     engines: {node: '>= 16.4.0'}
@@ -1924,6 +1940,10 @@ packages:
 
   '@electron-forge/tracer@7.10.2':
     resolution: {integrity: sha512-jhLLQbttfZViSOYn/3SJc8HML+jNZAytPVJwgGGd3coUiFysWJ2Xald99iqOiouPAhIigBfNPxQb/q/EbcDu4g==}
+    engines: {node: '>= 14.17.5'}
+
+  '@electron-forge/tracer@7.11.1':
+    resolution: {integrity: sha512-tiB6cglVQFcSw9N8GRwVwZUeB9u0DOx2Mj7aFXBUsFLUYQapvVGv51tUSy/UAW5lvmubGscYIILuVko+II3+NA==}
     engines: {node: '>= 14.17.5'}
 
   '@electron-forge/web-multi-logger@7.10.2':
@@ -2648,6 +2668,16 @@ packages:
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
+
+  '@malept/electron-installer-flatpak@0.11.4':
+    resolution: {integrity: sha512-ZdwhT4WeeJWdnsmALUtQ7bn4pzYVh0Vg+4NnF1S3n3OACc9IWg+B+LxI5gT3XSXIrxogouqkjM6gD8S592awyA==}
+    engines: {node: '>= 10.0.0'}
+    os: [darwin, linux]
+    hasBin: true
+
+  '@malept/flatpak-bundler@0.4.0':
+    resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
+    engines: {node: '>= 10.0.0'}
 
   '@mapbox/node-pre-gyp@2.0.3':
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
@@ -5080,6 +5110,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -6842,16 +6873,19 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-semver-tags@7.0.1:
     resolution: {integrity: sha512-NY0ZHjJzyyNXHTDZmj+GG7PyuAKtMsyWSwh07CR2hOZFa+/yoTsXci/nF2obzL8UDhakFNkD9gNdt/Ed+cxh2Q==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-semver-tags@8.0.0:
     resolution: {integrity: sha512-N7YRIklvPH3wYWAR2vysaqGLPRcpwQ0GKdlqTiVN5w1UmCdaeY3K8s6DMKRCh54DDdzyt/OAB6C8jgVtb7Y2Fg==}
     engines: {node: '>=18'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -13484,6 +13518,15 @@ snapshots:
       - bluebird
       - supports-color
 
+  '@electron-forge/maker-base@7.11.1':
+    dependencies:
+      '@electron-forge/shared-types': 7.11.1
+      fs-extra: 10.1.0
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
   '@electron-forge/maker-deb@7.10.2':
     dependencies:
       '@electron-forge/maker-base': 7.10.2
@@ -13501,6 +13544,17 @@ snapshots:
       fs-extra: 10.1.0
     optionalDependencies:
       electron-installer-dmg: 5.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  '@electron-forge/maker-flatpak@7.11.1':
+    dependencies:
+      '@electron-forge/maker-base': 7.11.1
+      '@electron-forge/shared-types': 7.11.1
+      fs-extra: 10.1.0
+    optionalDependencies:
+      '@malept/electron-installer-flatpak': 0.11.4
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -13625,6 +13679,16 @@ snapshots:
       - bluebird
       - supports-color
 
+  '@electron-forge/shared-types@7.11.1':
+    dependencies:
+      '@electron-forge/tracer': 7.11.1
+      '@electron/packager': 18.4.4
+      '@electron/rebuild': 3.7.2
+      listr2: 7.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
   '@electron-forge/template-base@7.10.2':
     dependencies:
       '@electron-forge/core-utils': 7.10.2
@@ -13681,6 +13745,10 @@ snapshots:
       - supports-color
 
   '@electron-forge/tracer@7.10.2':
+    dependencies:
+      chrome-trace-event: 1.0.4
+
+  '@electron-forge/tracer@7.11.1':
     dependencies:
       chrome-trace-event: 1.0.4
 
@@ -14568,6 +14636,28 @@ snapshots:
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
       cross-spawn: 7.0.6
+
+  '@malept/electron-installer-flatpak@0.11.4':
+    dependencies:
+      '@malept/flatpak-bundler': 0.4.0
+      debug: 4.4.3(supports-color@5.5.0)
+      electron-installer-common: 0.10.4
+      lodash: 4.17.23
+      semver: 7.7.4
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@malept/flatpak-bundler@0.4.0':
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      fs-extra: 9.1.0
+      lodash: 4.17.23
+      tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@mapbox/node-pre-gyp@2.0.3(encoding@0.1.13)':
     dependencies:


### PR DESCRIPTION
## Summary
Adds support for building Flatpak and RPM packages for Linux users, directly addressing the Steam Deck / Arch Linux request.

## Problem
Closes #51

Since there is no native officially supported Pacman maker for Electron Forge, and Steam Deck natively uses Flatpak for all desktop apps, adding Flatpak support directly resolves the issue for Steam Deck and works flawlessly on Arch Linux too! I also added an RPM maker just in case since it was commented out in the `forge.config.ts`.

## Solution
1. Configured `MakerFlatpak` and `MakerRpm` in `forge.config.ts`.
2. Updated `linux-release.yml` to install `rpm`, `flatpak`, and `flatpak-builder` on Ubuntu runner.
3. Updated `linux-release.yml` to deploy `.flatpak` and `.rpm` files to S3 bucket alongside the `.deb` file.

## Testing
- Modified packages config syntax correctly in `forge.config.ts`.
- `pnpm-lock.yaml` properly captures the updated package dependencies.
- Added `|| echo "No RPM built"` to AWS copy steps to avoid breaking builds if any makers optionally skip for some reason.